### PR TITLE
Re-apply greyout-style to modifiers on every update in greyout style

### DIFF
--- a/keys-indicator@caasiu.github.com/extension.js
+++ b/keys-indicator@caasiu.github.com/extension.js
@@ -218,6 +218,10 @@ const KeysIndicator = new Lang.Class({
         //key <Win> number is 64 
         if ((multiKeysCode >= 64)&&(multiKeysCode <= 77)){multiKeysCode = multiKeysCode - 64; }
 
+	this.keyAlt.add_style_class_name("grayout-style");
+	this.keyCtrl.add_style_class_name("grayout-style");
+	this.keyShift.add_style_class_name("grayout-style");
+	
         switch(multiKeysCode){
             case 1:
                 this.keyShift.remove_style_class_name("grayout-style");
@@ -245,10 +249,6 @@ const KeysIndicator = new Lang.Class({
                 this.keyCtrl.remove_style_class_name("grayout-style");
                 this.keyShift.remove_style_class_name("grayout-style");
                 break;
-            default:
-                this.keyAlt.add_style_class_name("grayout-style");
-                this.keyCtrl.add_style_class_name("grayout-style");
-                this.keyShift.add_style_class_name("grayout-style");
         }
     },
 


### PR DESCRIPTION
Hi

I am finding this extension to be very useful but I noticed an issue in grey-out mode.

If you press down more than one modifier and release one of them, all modifiers remain highlighted until you release them all. For example if you press down <kbd>Ctrl</kbd> + <kbd>Shift</kbd>, then release <kbd>Shift</kbd>; both <kbd>Ctrl</kbd> and <kbd>Shift</kbd> will be highlighted until you release <kbd>Ctrl</kbd>.

This PR includes a simple change that resets <kbd>Ctrl</kbd>, <kbd>Shift</kbd> and <kbd>Alt</kbd> styles on each update event.

Many thanks
Adrian

